### PR TITLE
remove logging to the config volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,5 +57,5 @@ VOLUME /config
 
 EXPOSE 8080
 
-ENTRYPOINT ["/src/domoticz/domoticz", "-dbase", "/config/domoticz.db", "-log", "/config/domoticz.log"]
+ENTRYPOINT ["/src/domoticz/domoticz", "-dbase", "/config/domoticz.db"]
 CMD ["-www", "8080"]

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -61,5 +61,5 @@ VOLUME /config
 
 EXPOSE 8080
 
-ENTRYPOINT ["/src/domoticz/domoticz", "-dbase", "/config/domoticz.db", "-log", "/config/domoticz.log"]
+ENTRYPOINT ["/src/domoticz/domoticz", "-dbase", "/config/domoticz.db"]
 CMD ["-www", "8080"]


### PR DESCRIPTION
Domoticz will still log to stdout, which can be managed by docker as usual.